### PR TITLE
MacOS build/export support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,22 @@ jobs:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+  # This job is where we compile Rust source code for MacOS target
+  rust-macos:
+    runs-on: macos-latest
+    name: Building Rust source for MacOS
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check Rust toolchain
+      run: rustup show
+    - name: Build
+      run: cargo build --release
+    - name: Upload GDNative library as artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: libcore.a
+        path: target/x86_64-pc-windows-gnu/release/libcore.a
+
   # This job is where we compile Rust source code for Android targets
   rust-android:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,15 @@ jobs:
       run: rustup show
     - name: Build
       run: cargo build --release
-    - name: Upload GDNative library as artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: libcore.a
-        path: target/release/libcore.a
+    - name: Troubleshooting MacOS target directory
+      run: ls target/
+    - name: Troubleshooting MacOS release directory
+      run: ls target/release/
+    # - name: Upload GDNative library as artifact
+    #   uses: actions/upload-artifact@v1
+    #   with:
+    #     name: libcore.a
+    #     path: target/release/libcore.a
 
   # This job is where we compile Rust source code for Android targets
   rust-android:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
     - name: Upload MacOS game as artifact
       uses: actions/upload-artifact@v1
       with:
-        name: sample_godot_rust_app.app
+        name: sample_godot_rust_app_macos
         path: build/macos
 
   # This job is where we build a Godot game for Android with debug mode,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
         name: libcore.dylib
         path: target/stable-x86_64-apple-darwin/release
     - name: Building for MacOS
-      run: godot -v --export "Mac OSX" ./build/macos/sample_godot_rust_app
+      run: godot -v --export "Mac OSX" ./build/macos/sample_godot_rust_app.zip
     - name: Upload MacOS game as artifact
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: libcore.a
-        path: target/x86_64-pc-windows-gnu/release/libcore.a
+        path: target/release/libcore.a
 
   # This job is where we compile Rust source code for Android targets
   rust-android:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,15 +77,11 @@ jobs:
       run: rustup show
     - name: Build
       run: cargo build --release
-    - name: Troubleshooting MacOS target directory
-      run: ls target/
-    - name: Troubleshooting MacOS release directory
-      run: ls target/release/
-    # - name: Upload GDNative library as artifact
-    #   uses: actions/upload-artifact@v1
-    #   with:
-    #     name: libcore.a
-    #     path: target/release/libcore.a
+    - name: Upload GDNative library as artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: libcore.dylib
+        path: target/release/libcore.dylib
 
   # This job is where we compile Rust source code for Android targets
   rust-android:
@@ -218,6 +214,40 @@ jobs:
       with:
         name: sample_godot_rust_app_windows
         path: build/windows
+
+  # This job is where we build a Godot game for MacOS,
+  # using the MacOS-compatible library we built in 'rust-macos'
+  godot-macos:
+    runs-on: ubuntu-latest
+    needs: rust-macos
+    name: Building Godot game for MacOS
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup environment
+      run: |
+        wget https://downloads.tuxfamily.org/godotengine/3.2.1/Godot_v3.2.1-stable_linux_headless.64.zip
+        wget https://downloads.tuxfamily.org/godotengine/3.2.1/Godot_v3.2.1-stable_export_templates.tpz
+        mkdir ~/.cache
+        mkdir -p ~/.config/godot
+        mkdir -p ~/.local/share/godot/templates/3.2.1.stable
+        unzip Godot_v3.2.1-stable_linux_headless.64.zip
+        sudo mv Godot_v3.2.1-stable_linux_headless.64 /usr/local/bin/godot
+        unzip Godot_v3.2.1-stable_export_templates.tpz
+        sudo mv templates/* ~/.local/share/godot/templates/3.2.1.stable
+        sudo rm -f Godot_v3.2.1-stable_linux_headless.64.zip Godot_v3.2.1-stable_export_templates.tpz
+        mkdir -p ./build/macos
+    - name: Download GDNative library artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: libcore.dylib
+        path: target/stable-x86_64-apple-darwin/release
+    - name: Building for MacOS
+      run: godot -v --export "Mac OSX" ./build/macos/sample_godot_rust_app
+    - name: Upload MacOS game as artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: sample_godot_rust_app.app
+        path: build/macos
 
   # This job is where we build a Godot game for Android with debug mode,
   # using the libraries we built for ARMv7, AArch64, x86 and x86_64 architectures

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 - Worry-free multi-platform builds and exports via Github Actions
 
 <p align="left">
-  <sub><b>Currently supported : </b>Linux ✅ Windows ✅ Android ✅<sub>
+  <sub><b>Currently supported : </b>Linux ✅ Windows ✅ MacOS ✅ Android ✅<sub>
 </p>
 
 ## Stack
@@ -303,7 +303,7 @@ Here is the list of all known supported and tested targets :
 | ------------------------------------------------------------ | ------- | ------------------------------------------------------------ |
 | <img src="https://img.icons8.com/color/2x/windows-10.png" alt="drawing" height="28" width="28"/> | Windows | ✅ `stable-x86_64-pc-windows-msvc`<br />✅ `x86_64-pc-windows-gnu` |
 | <img src="https://img.icons8.com/color/2x/linux.png" alt="drawing" height="35" width="34"/> | Linux   | ✅ `stable-x86_64-unknown-linux-gnu`                          |
-| <img src="https://img.icons8.com/office/2x/mac-os.png" alt="drawing" height="28" width="28"/> | MacOS   | ❓ `x86_64-apple-darwin`<br />Not tested yet ([#9](https://github.com/tommywalkie/sample-godot-rust-app/issues/9)) |
+| <img src="https://img.icons8.com/office/2x/mac-os.png" alt="drawing" height="28" width="28"/> | MacOS   | ✅ `x86_64-apple-darwin`                                      |
 | <img src="https://img.icons8.com/color/2x/android-os.png" alt="drawing" height="27" width="32"/> | Android | ✅ `armv7-linux-androideabi`<br />✅ `aarch64-linux-android `<br />✅ `i686-linux-android `<br />✅ `x86_64-linux-android ` |
 | <img src="https://img.icons8.com/ios-filled/2x/ios-logo.png" alt="drawing" height="28" width="28"/> | iOS     | ❓ `aarch64-apple-ios`<br />❓ `x86_64-apple-ios`<br />❓ `armv7-apple-ios`<br />❓ `armv7s-apple-ios`<br />❓ `i386-apple-ios`<br />Might be possible, using static libraries instead of dynamic ones ([godot-rust#285](https://github.com/GodotNativeTools/godot-rust/issues/285)) |
 
@@ -408,7 +408,7 @@ The only purpose of the CI workflow is to abstract the Rust source compilation a
 
 - [x] Release a <img src="https://img.icons8.com/color/2x/windows-10.png" alt="drawing" height="21" width="21"/> Windows executable
 - [x] Release a <img src="https://img.icons8.com/color/2x/linux.png" alt="drawing" height="23" width="25"/> Linux executable
-- [ ] Release a <img src="https://img.icons8.com/office/2x/mac-os.png" alt="drawing" height="21" width="21"/> MacOS executable
+- [x] Release a <img src="https://img.icons8.com/office/2x/mac-os.png" alt="drawing" height="21" width="21"/> MacOS executable
 - [x] Release an <img src="https://img.icons8.com/color/2x/android-os.png" alt="drawing" height="21" width="21"/> Android application
 - [ ] Release an <img src="https://img.icons8.com/ios-filled/2x/ios-logo.png" alt="drawing" height="21" width="21"/> iOS application (_if possible_)
 
@@ -416,6 +416,6 @@ The only purpose of the CI workflow is to abstract the Rust source compilation a
 
 - [x] Release a <img src="https://img.icons8.com/color/2x/windows-10.png" alt="drawing" height="21" width="21"/> Windows executable via Github Actions
 - [x] Release a <img src="https://img.icons8.com/color/2x/linux.png" alt="drawing" height="23" width="25"/> Linux executable via Github Actions
-- [ ] Release a <img src="https://img.icons8.com/office/2x/mac-os.png" alt="drawing" height="21" width="21"/> MacOS executable via Github Actions
+- [x] Release a <img src="https://img.icons8.com/office/2x/mac-os.png" alt="drawing" height="21" width="21"/> MacOS executable via Github Actions
 - [x] Release an <img src="https://img.icons8.com/color/2x/android-os.png" alt="drawing" height="21" width="21"/> Android application via Github Actions
 - [ ] Release an <img src="https://img.icons8.com/ios-filled/2x/ios-logo.png" alt="drawing" height="21" width="21"/> iOS application via Github Actions (_if possible_)

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -266,3 +266,36 @@ permissions/write_sms=false
 permissions/write_social_stream=false
 permissions/write_sync_settings=false
 permissions/write_user_dictionary=false
+
+[preset.3]
+
+name="Mac OSX"
+platform="Mac OSX"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="build/sample_godot_rust_app.zip"
+patch_list=PoolStringArray(  )
+script_export_mode=1
+script_encryption_key=""
+
+[preset.3.options]
+
+custom_template/debug=""
+custom_template/release=""
+application/name=""
+application/info="Made with Godot Engine"
+application/icon=""
+application/identifier=""
+application/signature=""
+application/short_version="1.0"
+application/version="1.0"
+application/copyright=""
+display/high_res=false
+privacy/camera_usage_description=""
+privacy/microphone_usage_description=""
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false

--- a/scenes/core.gdnlib
+++ b/scenes/core.gdnlib
@@ -1,7 +1,7 @@
 [entry]
 
 X11.64="res://target/stable-x86_64-unknown-linux-gnu/release/libcore.so"
-OSX.64="res://target/stable-x86_64-apple-darwin/release/core.dylib"
+OSX.64="res://target/stable-x86_64-apple-darwin/release/libcore.dylib"
 Windows.64="res://target/x86_64-pc-windows-gnu/release/core.dll"
 Android.armeabi-v7a="res://target/armv7-linux-androideabi/release/libcore.so"
 Android.arm64-v8a="res://target/aarch64-linux-android/release/libcore.so"

--- a/scenes/core.gdnlib
+++ b/scenes/core.gdnlib
@@ -1,7 +1,7 @@
 [entry]
 
 X11.64="res://target/stable-x86_64-unknown-linux-gnu/release/libcore.so"
-OSX.64="res://target/x86_64-apple-darwin/release/core.dylib"
+OSX.64="res://target/stable-x86_64-apple-darwin/release/core.dylib"
 Windows.64="res://target/x86_64-pc-windows-gnu/release/core.dll"
 Android.armeabi-v7a="res://target/armv7-linux-androideabi/release/libcore.so"
 Android.arm64-v8a="res://target/aarch64-linux-android/release/libcore.so"


### PR DESCRIPTION
Self explanatory. Now it supports MacOS exports but it will still be affected by a known Godot issue https://github.com/tommywalkie/sample-godot-rust-app/issues/10 for some time. There will be an upcoming PR for this.