### PR TITLE
Optimized Windows CI by ditching rust-embedded/cross

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,26 +45,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Check Rust toolchain
       run: rustup show
-    - name: Install Cross
-      run: cargo install cross
-    - name: Build custom Docker image for x86_64-pc-windows-gnu toolchain with LLVM
-      run: docker build -t my/x86_64-pc-windows-gnu:latest -f ./dockerfiles/x86_64-pc-windows-gnu.Dockerfile .
-    - name: Build with Cross
-      run: cross build --release --target x86_64-pc-windows-gnu
-    - name: Upload GDNative library as artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: core.dll
-        path: target/x86_64-pc-windows-gnu/release/core.dll
-
-  # This job is where we compile Rust source code for Windows target without Cross
-  rust-windows-new:
-    runs-on: ubuntu-latest
-    name: Building Rust source for Windows without Cross
-    steps:
-    - uses: actions/checkout@v2
-    - name: Check Rust toolchain
-      run: rustup show
     - name: Install Rust toolchain
       run: rustup target add x86_64-pc-windows-gnu
     - name: Update apt-get
@@ -76,14 +56,18 @@ jobs:
     - name: Install MinGW GCC linker
       run: sudo apt-get install gdb-mingw-w64 gcc-mingw-w64-x86-64 -y
     - name: Setup Cargo with MinGW GCC linker
-      run: |
-        ls ~/.cargo/  
+      run: | 
         touch ~/.cargo/config
         echo '[target.x86_64-pc-windows-gnu]' >> ~/.cargo/config
         echo 'linker = "/usr/bin/x86_64-w64-mingw32-gcc"' >> ~/.cargo/config
         cat ~/.cargo/config
     - name: Build with Cargo
       run: cargo build --release --target x86_64-pc-windows-gnu
+    - name: Upload GDNative library as artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: core.dll
+        path: target/x86_64-pc-windows-gnu/release/core.dll
 
   # This job is where we compile Rust source code for Android targets
   rust-android:
@@ -105,7 +89,6 @@ jobs:
       run: sudo apt-get install g++-multilib gcc-multilib libc6-dev-i386 -y
     - name: Registering a NDK based Clang linker to Cargo
       run: |
-        ls ~/.cargo/  
         touch ~/.cargo/config
         echo '[target.armv7-linux-androideabi]' >> ~/.cargo/config
         echo 'linker = "/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi29-clang"' >> ~/.cargo/config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Install MinGW GCC linker
       run: sudo apt-get install gdb-mingw-w64 gcc-mingw-w64-x86-64 -y
     - name: Setup Cargo with MinGW GCC linker
-      run: run: |
+      run: |
         ls ~/.cargo/  
         touch ~/.cargo/config
         echo '[target.x86_64-pc-windows-gnu]' >> ~/.cargo/config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,23 @@ jobs:
     - uses: actions/checkout@v2
     - name: Check Rust toolchain
       run: rustup show
+    - name: Install Rust toolchain
+      run: rustup target add x86_64-pc-windows-gnu
     - name: Update apt-get
       run: sudo apt-get update
     - name: Setting up llvm-config
       run: sudo apt-get install llvm-dev -y
     - name: Check if llvm-config exists
       run: llvm-config --version
-    - name: Install Rust toolchain
-      run: rustup target add x86_64-pc-windows-gnu
+    - name: Install MinGW GCC linker
+      run: sudo apt-get install gdb-mingw-w64 gcc-mingw-w64-x86-64 -y
+    - name: Setup Cargo with MinGW GCC linker
+      run: run: |
+        ls ~/.cargo/  
+        touch ~/.cargo/config
+        echo '[target.x86_64-pc-windows-gnu]' >> ~/.cargo/config
+        echo 'linker = "/usr/bin/x86_64-w64-mingw32-gcc"' >> ~/.cargo/config
+        cat ~/.cargo/config
     - name: Build with Cargo
       run: cargo build --release --target x86_64-pc-windows-gnu
 
@@ -99,16 +108,12 @@ jobs:
         ls ~/.cargo/  
         touch ~/.cargo/config
         echo '[target.armv7-linux-androideabi]' >> ~/.cargo/config
-        echo 'ar = "/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/arm-linux-androideabi-ar"' >> ~/.cargo/config
         echo 'linker = "/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi29-clang"' >> ~/.cargo/config
         echo '[target.aarch64-linux-android]' >> ~/.cargo/config
-        echo 'ar = "/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"' >> ~/.cargo/config
         echo 'linker = "/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang"' >> ~/.cargo/config
         echo '[target.i686-linux-android]' >> ~/.cargo/config
-        echo 'ar = "/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android-ar"' >> ~/.cargo/config
         echo 'linker = "/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android29-clang"' >> ~/.cargo/config
         echo '[target.x86_64-linux-android]' >> ~/.cargo/config
-        echo 'ar = "/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android-ar"' >> ~/.cargo/config
         echo 'linker = "/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android29-clang"' >> ~/.cargo/config
         cat ~/.cargo/config
     - name: Build with Cargo for ARMv7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on: push
 # on:
 #   push:
 #     paths:
-#     - 'dockerfiles/**'
 #     - 'assets/**'
 #     - 'scenes/**'
 #     - 'src/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,6 @@ jobs:
       with:
         name: libcore.so
         path: target/release/libcore.so
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
   # This job is where we compile Rust source code for Windows target
   rust-windows:
@@ -61,11 +56,25 @@ jobs:
       with:
         name: core.dll
         path: target/x86_64-pc-windows-gnu/release/core.dll
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+  # This job is where we compile Rust source code for Windows target without Cross
+  rust-windows-new:
+    runs-on: ubuntu-latest
+    name: Building Rust source for Windows without Cross
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check Rust toolchain
+      run: rustup show
+    - name: Update apt-get
+      run: sudo apt-get update
+    - name: Setting up llvm-config
+      run: sudo apt-get install llvm-dev -y
+    - name: Check if llvm-config exists
+      run: llvm-config --version
+    - name: Install Rust toolchain
+      run: rustup target add x86_64-pc-windows-gnu
+    - name: Build with Cargo
+      run: cargo build --release --target x86_64-pc-windows-gnu
 
   # This job is where we compile Rust source code for Android targets
   rust-android:

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,0 @@
-# Use a custom Docker image with LLVM installed
-# to compile for Windows from Linux
-
-[target.x86_64-pc-windows-gnu]
-image = "my/x86_64-pc-windows-gnu:latest"

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ speculate! {
 
 ## Exporting
 
-Under the hood, this boilerplate is using Github Actions, Docker, [`rust-embedded/cross`](https://github.com/rust-embedded/cross) and a headless Godot Engine instance to test, build and export for multiple platforms, allowing users to focus on game development while abstracting a lot of tedious tasks, using a `export_presets.cfg` file at the root of the project.
+Under the hood, this boilerplate is using Github Actions and a headless Godot Engine instance to test, build and export for multiple platforms, allowing users to focus on game development while abstracting a lot of tedious tasks, using a `export_presets.cfg` file at the root of the project.
 
 Here is the current workflow :
 

--- a/dockerfiles/x86_64-pc-windows-gnu.Dockerfile
+++ b/dockerfiles/x86_64-pc-windows-gnu.Dockerfile
@@ -1,7 +1,0 @@
-# This Docker image allows us to use 'x86_64-pc-windows-gnu' toolchain
-# while also installing LLVM, which is required by 'gdnative-sys' crate.
-
-FROM rustembedded/cross:x86_64-pc-windows-gnu
-
-RUN apt-get update && \
-    apt-get install clang-format clang-tidy clang-tools clang libc++-dev libc++1 libc++abi-dev libc++abi1 libclang-dev libclang1 libomp-dev libomp5 lld lldb llvm-dev llvm-runtime llvm -y


### PR DESCRIPTION
Related to https://github.com/tommywalkie/sample-godot-rust-app/issues/16.
Ditched unnecessary `rust-embedded/cross` setup in favor of using `gdb-mingw-w64` and `gcc-mingw-w64-x86-6` APT packages allowing us to get access to a MinGW compatible GCC linker.